### PR TITLE
feat: add toggle mode keyboard shortcut

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -4,5 +4,8 @@
   },
   "extDescription": {
     "message": "One-click Toggle for Web Page Dark Mode"
+  },
+  "extToggleDarkMode": {
+    "message": "Toggle Dark Mode"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -4,5 +4,8 @@
   },
   "extDescription": {
     "message": "暗黑模式一键切换"
+  },
+  "extToggleDarkMode": {
+    "message": "切换暗黑模式"
   }
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -20,4 +20,29 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 })
 
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle_dark_mode') {
+    state.isDark = !state.isDark
+
+    chrome.runtime.sendMessage({
+      action: 'updatePopupConfig'
+    })
+
+    chrome.tabs.query({}, (tabs) => {
+      tabs.forEach((tab) => {
+        if (tab.id) {
+          chrome.tabs.sendMessage(tab.id, {
+            info: 'changeMode',
+            data: { exclude: false }
+          }, _ => {
+            if (chrome.runtime.lastError) {
+              return
+            }
+          })
+        }
+      })
+    })
+  }
+})
+
 export {}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,11 +5,13 @@
   "sepia": "Sepia",
   "global": "Global",
   "language": "Language",
+  "shortcut": "Shortcut",
   "rate": "Rate",
   "feedback": "Feedback",
   "protectedTips": "This page is protected by the browser",
   "excludePath": "Exdomains",
   "excludeTips": "Current URL has been ignored",
   "excludePlaceholder": "google.com/* Separate by pressing the Enter key",
-  "version": "Version"
+  "version": "Version",
+  "notSet": "Not set"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -5,11 +5,13 @@
   "sepia": "复古褐",
   "global": "全局模式",
   "language": "语言",
+  "shortcut": "快捷键",
   "rate": "评分",
   "feedback": "反馈",
   "protectedTips": "此页面受浏览器保护",
   "excludePath": "排除域名",
   "excludeTips": "当前 URL 已被设置为全局忽略域名",
   "excludePlaceholder": "google.com/* 并使用换行/Enter键分隔",
-  "version": "版本"
+  "version": "版本",
+  "notSet": "未设置"
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -10,6 +10,14 @@ export default defineManifest({
     default_popup: 'popup.html',
     default_icon: 'imgs/logo16.png',
   },
+  commands: {
+    toggle_dark_mode: {
+      suggested_key: {
+        default: 'Alt+D'
+      },
+      description: '__MSG_extToggleDarkMode__'
+    }
+  },
   default_locale: 'en',
   background: {
     service_worker: 'src/background/index.ts',
@@ -28,6 +36,6 @@ export default defineManifest({
       matches: [],
     },
   ],
-  permissions: ['activeTab'],
+  permissions: ['activeTab', 'commands'],
   host_permissions: ['<all_urls>'],
 })

--- a/src/popup/Setting/index.module.scss
+++ b/src/popup/Setting/index.module.scss
@@ -111,6 +111,15 @@
         font-size: 14px;
         font-family: $number_font_family;
       }
+      .shortcutWrap {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .shortcutText {
+        font-size: 12px;
+        color: #666;
+      }
     }
   }
 }

--- a/src/popup/Setting/index.tsx
+++ b/src/popup/Setting/index.tsx
@@ -10,6 +10,7 @@ import { RiEmphasisCn } from 'react-icons/ri'
 import { LiaLanguageSolid } from 'react-icons/lia'
 import { RiFolderForbidLine } from 'react-icons/ri'
 import { FaCircleInfo } from 'react-icons/fa6'
+import { RiKeyboardLine } from 'react-icons/ri'
 
 import { useTranslation } from 'react-i18next'
 
@@ -32,6 +33,7 @@ const Setting = ({ onBack }: Setting) => {
   const [excludesDomains, setExcludesDomains] = useState<string>(
     localStorage.getItem(EXCLUDE_URLS_KEY) || '',
   )
+  const [currentShortcut, setCurrentShortcut] = useState<string>()
 
   const { i18n, t } = useTranslation()
 
@@ -41,6 +43,11 @@ const Setting = ({ onBack }: Setting) => {
         const { isGlobal } = response.state
         setGlobal(isGlobal)
       }
+    })
+
+    chrome.commands.getAll((commands) => {
+      const darkModeCommand = commands.find(cmd => cmd.name === 'toggle_dark_mode')
+      setCurrentShortcut(darkModeCommand?.shortcut)
     })
   }, [])
 
@@ -97,6 +104,10 @@ const Setting = ({ onBack }: Setting) => {
       i18n.changeLanguage('zh')
       localStorage.setItem('lang', 'zh')
     }
+  }
+
+  const shortcutSettingOnClick = () => {
+    chrome.tabs.create({ url: 'chrome://extensions/shortcuts' })
   }
 
   const rateOnClick = () => {
@@ -209,6 +220,16 @@ const Setting = ({ onBack }: Setting) => {
             ) : (
               <RiEmphasisCn size={22} className={styles.rightIcon} />
             )}
+          </span>
+        </div>
+        <div className={styles.item} onClick={shortcutSettingOnClick}>
+          <div className={styles.label}>
+            <RiKeyboardLine size={20} className={styles.icon} />
+            <span>{t('shortcut')}</span>
+          </div>
+          <span className={styles.shortcutWrap}>
+            <span className={styles.shortcutText}>{currentShortcut || t('notSet')}</span>
+            <FaAngleRight size={20} className={styles.rightIcon} />
           </span>
         </div>
         <div className={styles.item} onClick={rateOnClick}>

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -43,6 +43,10 @@ const Popup = () => {
 
   useEffect(() => {
     initCheck()
+    chrome.runtime.onMessage.addListener(handleMessage)
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleMessage)
+    }
   }, [])
 
   const initCheck = () => {
@@ -62,7 +66,17 @@ const Popup = () => {
     }
   }
 
+  const handleMessage = (message: { action: string }) => {
+    if (message.action === 'updatePopupConfig') {
+      updatePopupConfig()
+    }
+  }
+
   useEffect(() => {
+    updatePopupConfig()
+  }, [inSettingPage])
+
+  const updatePopupConfig = () => {
     chrome.runtime.sendMessage({ action: 'getGlobal' }, (response) => {
       if (response) {
         globalState = response.state
@@ -111,7 +125,7 @@ const Popup = () => {
         }
       }
     })
-  }, [inSettingPage])
+  }
 
   const onNotice = (config: Config) => {
     if (globalState.isGlobal) {


### PR DESCRIPTION
Add keyboard shortcut support (default: Alt+D) to quickly switch between light and dark modes. Users can customize the shortcut in Chrome's extension settings.